### PR TITLE
Fix defination of memchr

### DIFF
--- a/libgomp/config/linux/proc.c
+++ b/libgomp/config/linux/proc.c
@@ -34,6 +34,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <stdio.h>
+#include <string.h>
 #include <stdlib.h>
 #include <fcntl.h>
 #include <errno.h>


### PR DESCRIPTION
memchr() is define in string.h include string.h to fix it.

Signed-off-by: sayeed99 sayeed.afridi2009@gmail.com
